### PR TITLE
Change port to 443 to serve deployed site directly from Node

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -12,7 +12,7 @@ var userRouter = require('./routers/userRouter.js');
 
 
 // configuration variables for server port and mongodb URI
-var port = process.env.PORT || 4443;
+var port = process.env.PORT || 443;
 var dbUri = process.env.MONGOLAB_URI || 'mongodb://localhost/app_database';
 var env = process.env.NODE_ENV || 'production';
 


### PR DESCRIPTION
Was trying to use an Apache server at port 443 with reverse proxy
to the Node Server at port 4443. Ran into issues, so removing
Apache from the setup.
